### PR TITLE
feat: replace old Load Pyodide button with conditional validation button

### DIFF
--- a/components/validate.tsx
+++ b/components/validate.tsx
@@ -235,14 +235,6 @@ export default function ContainerValidator({
                                     </p>
                                 )}
                             </div>
-                            {!pyodide && !pyodideLoading && (
-                                <button
-                                    onClick={loadPyodide}
-                                    className={cn(buttonStyles(isDark, 'secondary', 'sm'))}
-                                >
-                                    Load Pyodide
-                                </button>
-                            )}
                         </div>
 
                         {/* Builder Status */}
@@ -375,22 +367,41 @@ export default function ContainerValidator({
                 <div className="mb-6">
                     <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4">
                         <h3 className={textStyles(isDark, { size: 'lg', weight: 'medium', color: 'primary' })}>Validation</h3>
-                        <button
-                            onClick={validateRecipe}
-                            disabled={!canValidate}
-                            className={cn(
-                                buttonStyles(isDark, 'primary', 'md'),
-                                "flex items-center gap-2",
-                                !canValidate && "disabled:opacity-50 disabled:cursor-not-allowed"
-                            )}
-                        >
-                            {validating ? (
-                                <ArrowPathIcon className={cn(iconStyles(isDark, 'sm'), "animate-spin")} />
-                            ) : (
-                                <PlayIcon className={iconStyles(isDark, 'sm')} />
-                            )}
-                            {validating ? "Validating..." : "Validate & Generate"}
-                        </button>
+                        {!pyodide ? (
+                            <button
+                                onClick={loadPyodide}
+                                disabled={pyodideLoading}
+                                className={cn(
+                                    buttonStyles(isDark, 'primary', 'md'),
+                                    "flex items-center gap-2",
+                                    pyodideLoading && "disabled:opacity-50 disabled:cursor-not-allowed"
+                                )}
+                            >
+                                {pyodideLoading ? (
+                                    <ArrowPathIcon className={cn(iconStyles(isDark, 'sm'), "animate-spin")} />
+                                ) : (
+                                    <PlayIcon className={iconStyles(isDark, 'sm')} />
+                                )}
+                                {pyodideLoading ? "Loading Pyodide..." : "Load Pyodide"}
+                            </button>
+                        ) : (
+                            <button
+                                onClick={validateRecipe}
+                                disabled={!canValidate}
+                                className={cn(
+                                    buttonStyles(isDark, 'primary', 'md'),
+                                    "flex items-center gap-2",
+                                    !canValidate && "disabled:opacity-50 disabled:cursor-not-allowed"
+                                )}
+                            >
+                                {validating ? (
+                                    <ArrowPathIcon className={cn(iconStyles(isDark, 'sm'), "animate-spin")} />
+                                ) : (
+                                    <PlayIcon className={iconStyles(isDark, 'sm')} />
+                                )}
+                                {validating ? "Validating..." : "Validate & Generate"}
+                            </button>
+                        )}
                     </div>
 
                     {disabled && disabledReason && (


### PR DESCRIPTION
Remove redundant Load Pyodide button from status section and implement conditional rendering in validation section:

- Show 'Load Pyodide' when Pyodide not loaded
- Show 'Loading Pyodide...' when loading (disabled with spinner)
- Show 'Validate & Generate' when Pyodide ready

Improves UX by providing clear actionable steps to users.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)