### PR TITLE
Add icon editor feature for container recipes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@heroicons/react": "^2.2.0",
         "@types/pako": "^2.0.3",
         "js-yaml": "^4.1.0",
-        "next": "15.3.2",
+        "next": "15.3.3",
         "pako": "^2.1.0",
         "pyodide": "^0.27.6",
         "react": "^19.0.0",
@@ -121,25 +121,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.10", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.9.0" } }, "sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ=="],
 
-    "@next/env": ["@next/env@15.3.2", "", {}, "sha512-xURk++7P7qR9JG1jJtLzPzf0qEvqCN0A/T3DXf8IPMKo9/6FfjxtEffRJIIew/bIL4T3C2jLLqBor8B/zVlx6g=="],
+    "@next/env": ["@next/env@15.3.3", "", {}, "sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.3.2", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-ijVRTXBgnHT33aWnDtmlG+LJD+5vhc9AKTJPquGG5NKXjpKNjc62woIhFtrAcWdBobt8kqjCoaJ0q6sDQoX7aQ=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2DR6kY/OGcokbnCsjHpNeQblqCZ85/1j6njYSkzRdpLn5At7OkSdmk7WyAmB9G0k25+VgqVZ/u356OSoQZ3z0g=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WRJERLuH+O3oYB4yZNVahSVFmtxRNjNF1I1c34tYMoJb0Pve+7/RaLAJJizyYiFhjYNGHRAE1Ri2Fd23zgDqhg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ro/fdqaZWL6k1S/5CLv1I0DaZfDVJkWNaUU3un8Lg6m0YENWlDulmIWzV96Iou2wEYyEsZq51mwV8+XQXqMp3w=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-XHdzH/yBc55lu78k/XwtuFR/ZXUTcflpRXcsu0nKmF45U96jt1tsOZhVrn5YH+paw66zOANpOnFQ9i6/j+UYvw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-covwwtZYhlbRWK2HlYX9835qXum4xYZ3E2Mra1mdQ+0ICGoMiw1+nVAn4d9Bo7R3JqSmK1grMq/va+0cdh7bJA=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VZ3sYL2LXB8znNGcjhocikEkag/8xiLgnvQts41tq6i+wql63SMS1Q6N8RVXHw5pEUjiof+II3HkDd7GFcgkzw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-KQkMEillvlW5Qk5mtGA/3Yz0/tzpNlSw6/3/ttsV1lNtMuOHcGii3zVeXZyi4EJmmLDKYcTcByV2wVsOhDt/zg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-h6Y1fLU4RWAp1HPNJWDYBQ+e3G7sLckyBXhmH9ajn8l/RSMnhbuPBV/fXmy3muMcVwoJdHL+UtzRzs0nXOf9SA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uRBo6THWei0chz+Y5j37qzx+BtoDRFIkDzZjlpCItBRXyMPIg079eIkOCl3aqr2tkxL4HFyJ4GHDes7W8HuAUg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-jJ8HRiF3N8Zw6hGlytCj5BiHyG/K+fnTKVDEKvUCyiQ/0r5tgwO7OgaRiOjjRoIx2vwLR+Rz8hQoPrnmFbJdfw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-+uxFlPuCNx/T9PdMClOqeE8USKzj8tVz37KflT3Kdbx/LOlZBRI2yxuIcmx1mPNK8DwSOMNCr4ureSet7eyC0w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-HrUcTr4N+RgiiGn3jjeT6Oo208UT/7BuTr7K0mdKRBtTbT4v9zJqCDKO97DUqqoBK1qyzP1RwvrWTvU6EPh/Cw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-LLTKmaI5cfD8dVzh5Vt7+OMo+AIOClEdIU/TSKbXXT2iScUTSxOGoBhfuv+FU8R9MLmrkIL1e2fBMkEEjYAtPQ=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-SxorONgi6K7ZUysMtRF3mIeHC5aA3IQLmKFQzU0OuhuUYwpOBc1ypaLJLP5Bf3M9k53KUUUj4vTPwzGvl/NwlQ=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-aW5B8wOPioJ4mBdMDXkt5f3j8pUr9W8AnlX0Df35uRWNT1Y6RIybxjnSUe+PhM+M1bwgyY8PHLmXZC6zT1o5tA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4QZG6F8enl9/S2+yIiOiju0iCTFd93d8VC1q9LZS4p/Xuk81W2QDjCFeoogmrWWkAD59z8ZxepBQap2dKS5ruw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -731,7 +731,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@15.3.2", "", { "dependencies": { "@next/env": "15.3.2", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.2", "@next/swc-darwin-x64": "15.3.2", "@next/swc-linux-arm64-gnu": "15.3.2", "@next/swc-linux-arm64-musl": "15.3.2", "@next/swc-linux-x64-gnu": "15.3.2", "@next/swc-linux-x64-musl": "15.3.2", "@next/swc-win32-arm64-msvc": "15.3.2", "@next/swc-win32-x64-msvc": "15.3.2", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-CA3BatMyHkxZ48sgOCLdVHjFU36N7TF1HhqAHLFOkV6buwZnvMI84Cug8xD56B9mCuKrqXnLn94417GrZ/jjCQ=="],
+    "next": ["next@15.3.3", "", { "dependencies": { "@next/env": "15.3.3", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.3", "@next/swc-darwin-x64": "15.3.3", "@next/swc-linux-arm64-gnu": "15.3.3", "@next/swc-linux-arm64-musl": "15.3.3", "@next/swc-linux-x64-gnu": "15.3.3", "@next/swc-linux-x64-musl": "15.3.3", "@next/swc-win32-arm64-msvc": "15.3.3", "@next/swc-win32-x64-msvc": "15.3.3", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 

--- a/components/IconEditor.tsx
+++ b/components/IconEditor.tsx
@@ -1,0 +1,293 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+import { PhotoIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { cn, buttonStyles, textStyles } from "@/lib/styles";
+import { useTheme } from "@/lib/ThemeContext";
+import Image from "next/image";
+
+interface IconEditorProps {
+    value?: string; // Base64 encoded image
+    onChange: (icon: string | undefined) => void;
+    containerName: string;
+    error?: string | null;
+    showValidation?: boolean;
+}
+
+// Utility function to generate default icon from text
+const generateDefaultIcon = (text: string): string => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+    const ctx = canvas.getContext('2d');
+    
+    if (!ctx) return '';
+    
+    // Use a gradient background
+    const gradient = ctx.createLinearGradient(0, 0, 64, 64);
+    gradient.addColorStop(0, '#7bb33a');
+    gradient.addColorStop(1, '#4f7b38');
+    
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, 64, 64);
+    
+    // Add text
+    ctx.fillStyle = 'white';
+    ctx.font = 'bold 24px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    
+    // Extract 1-2 letters from text
+    const letters = text.trim().replace(/[^a-zA-Z0-9]/g, '').substring(0, 2).toUpperCase();
+    ctx.fillText(letters, 32, 32);
+    
+    return canvas.toDataURL('image/png');
+};
+
+// Utility function to resize and crop image to 64x64
+const resizeImageToIcon = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+        const img = new globalThis.Image();
+        img.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 64;
+            canvas.height = 64;
+            const ctx = canvas.getContext('2d');
+            
+            if (!ctx) {
+                reject(new Error('Failed to get canvas context'));
+                return;
+            }
+            
+            // Calculate dimensions to crop to square and resize to 64x64
+            const size = Math.min(img.width, img.height);
+            const x = (img.width - size) / 2;
+            const y = (img.height - size) / 2;
+            
+            // Draw cropped and resized image
+            ctx.drawImage(img, x, y, size, size, 0, 0, 64, 64);
+            
+            const dataUrl = canvas.toDataURL('image/png');
+            resolve(dataUrl);
+        };
+        
+        img.onerror = () => reject(new Error('Failed to load image'));
+        img.src = URL.createObjectURL(file);
+    });
+};
+
+export default function IconEditor({ value, onChange, containerName, error, showValidation }: IconEditorProps) {
+    const { isDark } = useTheme();
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [isGenerating, setIsGenerating] = useState(false);
+    const [dragOver, setDragOver] = useState(false);
+
+    // Generate default icon when container name changes and no icon is set
+    useEffect(() => {
+        if (!value && containerName.trim() && containerName.trim().length >= 1) {
+            const defaultIcon = generateDefaultIcon(containerName);
+            onChange(defaultIcon);
+        }
+    }, [containerName, value, onChange]);
+
+    const handleFileSelect = useCallback(async (file: File) => {
+        if (!file.type.startsWith('image/')) {
+            alert('Please select an image file');
+            return;
+        }
+        
+        setIsGenerating(true);
+        try {
+            const iconData = await resizeImageToIcon(file);
+            onChange(iconData);
+        } catch (error) {
+            console.error('Error processing image:', error);
+            alert('Failed to process image. Please try a different file.');
+        } finally {
+            setIsGenerating(false);
+        }
+    }, [onChange]);
+
+    const handleFileUpload = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            handleFileSelect(file);
+        }
+        // Reset input value
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
+    }, [handleFileSelect]);
+
+    const handleDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        setDragOver(false);
+        
+        const files = Array.from(event.dataTransfer.files);
+        const imageFile = files.find(file => file.type.startsWith('image/'));
+        
+        if (imageFile) {
+            handleFileSelect(imageFile);
+        } else {
+            alert('Please drop an image file');
+        }
+    }, [handleFileSelect]);
+
+    const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        setDragOver(true);
+    }, []);
+
+    const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        setDragOver(false);
+    }, []);
+
+    const generateDefault = useCallback(() => {
+        if (containerName.trim()) {
+            const defaultIcon = generateDefaultIcon(containerName);
+            onChange(defaultIcon);
+        }
+    }, [containerName, onChange]);
+
+    const removeIcon = useCallback(() => {
+        onChange(undefined);
+    }, [onChange]);
+
+    const triggerFileSelect = useCallback(() => {
+        fileInputRef.current?.click();
+    }, []);
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center gap-2">
+                <label className={textStyles(isDark, { weight: 'medium' })}>
+                    Container Icon
+                </label>
+                {showValidation && error && (
+                    <span className="text-red-500 text-sm">* {error}</span>
+                )}
+            </div>
+
+            <div className="flex items-start gap-4">
+                {/* Icon Preview */}
+                <div className="flex-shrink-0">
+                    <div className={cn(
+                        "w-16 h-16 rounded-lg border-2 flex items-center justify-center",
+                        isDark ? "border-gray-600 bg-gray-700" : "border-gray-300 bg-gray-50"
+                    )}>
+                        {value ? (
+                            <Image 
+                                src={value} 
+                                alt="Container icon" 
+                                width={64}
+                                height={64}
+                                className="w-full h-full rounded-lg object-cover"
+                                unoptimized
+                            />
+                        ) : (
+                            <PhotoIcon className={cn(
+                                "w-8 h-8",
+                                isDark ? "text-gray-400" : "text-gray-500"
+                            )} />
+                        )}
+                    </div>
+                </div>
+
+                {/* Upload/Controls Area */}
+                <div className="flex-1 space-y-3">
+                    {/* Upload Area */}
+                    <div
+                        className={cn(
+                            "border-2 border-dashed rounded-lg p-4 text-center cursor-pointer transition-colors",
+                            dragOver ? (
+                                isDark ? "border-[#7bb33a] bg-[#7bb33a]/10" : "border-[#4f7b38] bg-[#4f7b38]/10"
+                            ) : (
+                                isDark ? "border-gray-600 hover:border-gray-500" : "border-gray-300 hover:border-gray-400"
+                            ),
+                            isGenerating && "pointer-events-none opacity-50"
+                        )}
+                        onClick={triggerFileSelect}
+                        onDrop={handleDrop}
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                    >
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="image/*"
+                            onChange={handleFileUpload}
+                            className="hidden"
+                        />
+                        
+                        {isGenerating ? (
+                            <div className="space-y-2">
+                                <div className={cn(
+                                    "animate-spin h-6 w-6 border-2 border-t-transparent rounded-full mx-auto",
+                                    isDark ? "border-[#7bb33a]" : "border-[#4f7b38]"
+                                )}></div>
+                                <p className={textStyles(isDark, { size: 'sm', color: 'secondary' })}>
+                                    Processing image...
+                                </p>
+                            </div>
+                        ) : (
+                            <div className="space-y-2">
+                                <PhotoIcon className={cn(
+                                    "w-8 h-8 mx-auto",
+                                    isDark ? "text-gray-400" : "text-gray-500"
+                                )} />
+                                <div className="space-y-1">
+                                    <p className={textStyles(isDark, { size: 'sm', weight: 'medium' })}>
+                                        {dragOver ? 'Drop image here' : 'Click to upload or drag & drop'}
+                                    </p>
+                                    <p className={textStyles(isDark, { size: 'xs', color: 'secondary' })}>
+                                        Images will be automatically cropped and resized to 64×64 pixels
+                                    </p>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Action Buttons */}
+                    <div className="flex gap-2">
+                        <button
+                            type="button"
+                            onClick={generateDefault}
+                            className={buttonStyles(isDark, 'secondary', 'sm')}
+                            disabled={!containerName.trim() || isGenerating}
+                        >
+                            Generate Default
+                        </button>
+                        
+                        {value && (
+                            <button
+                                type="button"
+                                onClick={removeIcon}
+                                className={cn(
+                                    buttonStyles(isDark, 'secondary', 'sm'),
+                                    "text-red-500 hover:text-red-600"
+                                )}
+                                disabled={isGenerating}
+                            >
+                                <XMarkIcon className="w-4 h-4 mr-1" />
+                                Remove
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {/* Helper Text */}
+            <div className={cn(
+                "text-xs p-3 rounded-lg",
+                isDark ? "bg-gray-800/50 text-gray-300" : "bg-gray-50 text-gray-600"
+            )}>
+                <p className="mb-1"><strong>Tips:</strong></p>
+                <ul className="list-disc list-inside space-y-1">
+                    <li>Upload any image format (PNG, JPG, GIF, etc.)</li>
+                    <li>Images are automatically cropped to square and resized to 64×64 pixels</li>
+                    <li>Default icons are generated using the first 1-2 letters of the container name</li>
+                    <li>Icons are stored as base64 data in the YAML definition</li>
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/components/common.ts
+++ b/components/common.ts
@@ -181,6 +181,7 @@ export const CATEGORIES = {
 export interface ContainerRecipe {
     name: string;
     version: string;
+    icon?: string; // Base64 encoded image, 64x64 pixels
     copyright?: CopyrightInfo[];
     architectures: Architecture[];
     readme?: string;

--- a/components/metadata.tsx
+++ b/components/metadata.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui";
 import { iconStyles, textStyles, cn, cardStyles, buttonStyles, getHelpSection } from "@/lib/styles";
 import { useTheme } from "@/lib/ThemeContext";
+import IconEditor from "@/components/IconEditor";
 
 // Validation functions
 function validateName(name: string): string | null {
@@ -119,6 +120,10 @@ export default function ContainerMetadata({
 
     const updateVersion = (version: string) => {
         onChange({ ...recipe, version });
+    };
+
+    const updateIcon = (icon: string | undefined) => {
+        onChange({ ...recipe, icon });
     };
 
     const updateArchitectures = (architectures: Architecture[]) => {
@@ -233,6 +238,15 @@ export default function ContainerMetadata({
                         <li>Use semantic versioning (e.g., 1.0.0, 2.1.3)</li>
                         <li>Or tool-specific versions (e.g., 6.0.5, latest)</li>
                         <li>Helps users identify which version they&apos;re using</li>
+                    </ul>
+                </div>
+                <div>
+                    <strong>Container Icon:</strong>
+                    <ul className="list-disc list-inside mt-1 space-y-1">
+                        <li>Upload any image format (automatically resized to 64×64 pixels)</li>
+                        <li>Default icons are generated from the first 1-2 letters of the container name</li>
+                        <li>Icons are embedded as base64 data in the YAML definition</li>
+                        <li>Helps users visually identify containers in lists and interfaces</li>
                     </ul>
                 </div>
             </div>
@@ -354,6 +368,16 @@ export default function ContainerMetadata({
                             onNameEditStart={onNameEditStart}
                             onNameEditFinish={onNameEditFinish}
                         />
+
+                        {/* Icon Editor */}
+                        <div className="mt-6">
+                            <IconEditor
+                                value={recipe.icon}
+                                onChange={updateIcon}
+                                containerName={recipe.name}
+                                showValidation={showValidation}
+                            />
+                        </div>
                     </div>
 
                     {/* Architecture Section */}


### PR DESCRIPTION
Implements the icon editor feature requested in issue #9.

## Features
- Upload and crop images to 64x64 pixels
- Default icon generation from container name
- Base64 encoding into YAML definition
- Drag & drop support
- Integration with Basic Info section

## Technical Implementation
- Added optional icon field to ContainerRecipe interface
- Created IconEditor component with canvas-based image processing
- Full TypeScript support and Next.js optimization

Closes #9

Generated with [Claude Code](https://claude.ai/code)