### PR TITLE
Remove GitHub container list refresh button and make delete button handle refresh

### DIFF
--- a/components/RemoteContainersList.tsx
+++ b/components/RemoteContainersList.tsx
@@ -6,7 +6,6 @@ import {
     CloudIcon,
     ComputerDesktopIcon,
     TrashIcon,
-    ArrowPathIcon,
     MagnifyingGlassIcon,
     ExclamationTriangleIcon,
     EyeIcon,
@@ -118,23 +117,17 @@ export function RemoteContainersList({
                     </div>
                     <div className="flex items-center space-x-2">
                         {filesystemMode === 'remote' && (
-                            <>
-                                <button
-                                    onClick={refetch}
-                                    disabled={loading}
-                                    className={cn(buttonStyles(isDark, 'ghost', 'sm'), "disabled:opacity-50")}
-                                    title="Refresh recipes"
-                                >
-                                    <ArrowPathIcon className={cn(iconStyles(isDark, 'sm'), loading && 'animate-spin')} />
-                                </button>
-                                <button
-                                    onClick={clearCache}
-                                    className={cn(buttonStyles(isDark, 'ghost', 'sm'), "hover:text-red-600")}
-                                    title="Clear cache"
-                                >
-                                    <TrashIcon className={iconStyles(isDark, 'sm')} />
-                                </button>
-                            </>
+                            <button
+                                onClick={() => {
+                                    clearCache();
+                                    refetch();
+                                }}
+                                disabled={loading}
+                                className={cn(buttonStyles(isDark, 'ghost', 'sm'), "hover:text-red-600 disabled:opacity-50")}
+                                title="Clear cache and refresh"
+                            >
+                                <TrashIcon className={iconStyles(isDark, 'sm')} />
+                            </button>
                         )}
                     </div>
                 </div>


### PR DESCRIPTION
Removes the standalone refresh button from the GitHub container list and modifies the delete button to handle both cache clearing and refreshing functionality.

Changes:
- Removed standalone refresh button (ArrowPathIcon)
- Modified delete button to call both `clearCache()` and `refetch()`
- Updated button title to "Clear cache and refresh"
- Removed unused `ArrowPathIcon` import
- Added loading state handling to the delete button

Fixes #12

Generated with [Claude Code](https://claude.ai/code)