### PR TITLE
Make mamba the default for conda containers

### DIFF
--- a/components/directives/groups/minicondaYaml.tsx
+++ b/components/directives/groups/minicondaYaml.tsx
@@ -104,7 +104,7 @@ dependencies:
             name: "mamba",
             type: "boolean",
             required: false,
-            defaultValue: false,
+            defaultValue: true,
             description: "Use Mamba instead of Conda for faster package resolution and installation.",
         },
         {

--- a/components/directives/templates/miniconda.tsx
+++ b/components/directives/templates/miniconda.tsx
@@ -106,9 +106,8 @@ registerNeuroDockerTemplate({
                 name: "mamba",
                 type: "boolean",
                 required: false,
-                defaultValue: false,
-                description: "Use Mamba instead of Conda for faster package management",
-                advanced: true
+                defaultValue: true,
+                description: "Use Mamba instead of Conda for faster package management"
             }
         ]
     },


### PR DESCRIPTION
This PR makes mamba the default package manager for new containers using conda and ensures it's a non-advanced option.

Changes made:
- Set mamba defaultValue to true in miniconda template
- Set mamba defaultValue to true in minicondaYaml group
- Remove advanced flag from mamba option to make it non-advanced

Resolves #13

Generated with [Claude Code](https://claude.ai/code)